### PR TITLE
Update design overview to clarify that a chaining design has been chosen

### DIFF
--- a/doc/design/overview.md
+++ b/doc/design/overview.md
@@ -17,10 +17,7 @@ There are currently [three loader hooks](https://github.com/nodejs/node/tree/mas
 
 Custom loaders are intended to chain to support various concerns beyond the scope of core, such as build tooling, mocking, transpilation, etc.
 
-### Proposals
-
-* [Chaining Hooks “Iterative” Design](./proposal-chaining-iterative.md)
-* [Chaining Hooks “Middleware” Design](./proposal-chaining-middleware.md)
+We plan to support chaining via what we’re calling the [Chaining Hooks “Middleware” Design](./proposal-chaining-middleware.md).
 
 ## History
 


### PR DESCRIPTION
In a recent meeting we chose the “middleware” design, if I remember correctly, so I’m updating our design doc to reflect that. I’m leaving the other proposal in the repo but not linking to it, to avoid confusion.