### PR TITLE
Split roadmap into phases; add recent additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,17 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 
 - [ ] Support loading source when the return value of `load` has `format: 'commonjs'`. See https://github.com/nodejs/node/issues/34753#issuecomment-735921348 and https://github.com/nodejs/loaders-test/blob/835506a638c6002c1b2d42ab7137db3e7eda53fa/coffeescript-loader/loader.js#L45-L50.
 
-- [ ] Finish and stabilize `--experimental-vm-modules` so that `vm` fully supports ESM.
+- [ ] Finish and stabilize `--experimental-vm-modules` so that `node:vm` fully supports ESM.
 
 ### Milestone 2: Usability improvements
 
 - [ ] First-class support for [import maps](https://github.com/WICG/import-maps) that doesn’t require a custom loader.
 
-- [ ] Add helper/utility functions to reduce boilerplate in user-defined hooks
+- [ ] Add helper/utility functions to reduce boilerplate in user-defined hooks.
 
-   - [ ] Start with the functions that make up the ESM resolution algorithm as defined in the [spec](https://nodejs.org/api/esm.html#resolver-algorithm-specification). Create helper functions for each of the functions defined in that psuedocode: `esmResolve`, `packageImportsResolve`, `packageResolve`, `esmFileFormat`, `packageSelfResolve`, `readPackageJson`, `packageExportsResolve`, `lookupPackageScope`, `packageTargetResolve`, `packageImportsExportsResolve`, `patternKeyCompare`. (Not necessarily all with these exact names, but corresponding to these functions from the spec.)
+   - [ ] Start with a helper for retrieving the closest parent `package.json` associated with a specifier string (`getPackageMetadata` perhaps).
+
+   - [ ] Potentially include all the functions that make up the ESM resolution algorithm as defined in the [spec](https://nodejs.org/api/esm.html#resolver-algorithm-specification). Create helper functions for each of the functions defined in that psuedocode: `esmResolve`, `packageImportsResolve`, `packageResolve`, `esmFileFormat`, `packageSelfResolve`, `readPackageJson`, `packageExportsResolve`, `lookupPackageScope`, `packageTargetResolve`, `packageImportsExportsResolve`, `patternKeyCompare`. (Not necessarily all with these exact names, but corresponding to these functions from the spec.)
 
    - [ ] Follow up with similar helper functions that make up what happens within Node’s internal `load`. (Definitions to come.)
 
@@ -64,7 +66,7 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 
 - [ ] Hooks for customizing the REPL, including transpilation and tab completion. Support users pasting TypeScript (or CoffeeScript or whatever) into the REPL and having just as good an experience as with plain JavaScript.
 
-   - [ ] Support top-level `await` in the REPL, if possible.
+   - [ ] Support top-level `await` in the REPL API, if possible.
 
 - [ ] Hooks for customizing the stack trace (in other words, a hook version of `Error.prepareStackTrace`). This would allow transpiled languages to improve the output.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This team is spun off from the [Modules team](https://github.com/nodejs/modules)
 
 ### Milestone 1: Parity with CommonJS
 
-Before extending into new frontiers, we need to improve the loaders API enough that users can do just about everything they could do in CommonJS with ESM + loaders.
+Before extending into new frontiers, we need to improve the loaders API enough that users can do just about everything they could do in CommonJS with ESM + loaders. (Outside of loaders scope, but related to the goal of parity between CommonJS and ESM, is finishing and stabilizing `--experimental-vm-modules`.)
 
 - [x] Finish https://github.com/nodejs/node/pull/37468 / https://github.com/nodejs/node/pull/35524, simplifying the hooks to `resolve`, `load` and `globalPreloadCode`.
 
@@ -47,8 +47,6 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 - [ ] Provide a way to register loaders without a command-line flag, for example via a `"loaders"` field in `package.json`.
 
 - [ ] Support loading source when the return value of `load` has `format: 'commonjs'`. See https://github.com/nodejs/node/issues/34753#issuecomment-735921348 and https://github.com/nodejs/loaders-test/blob/835506a638c6002c1b2d42ab7137db3e7eda53fa/coffeescript-loader/loader.js#L45-L50.
-
-- [ ] Finish and stabilize `--experimental-vm-modules` so that `node:vm` fully supports ESM.
 
 ### Milestone 2: Usability improvements
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 
 - [ ] Add helper/utility functions to reduce boilerplate in user-defined hooks.
 
-   - [ ] Start with a helper for retrieving the closest parent `package.json` associated with a specifier string (`getPackageMetadata` perhaps).
+   - [ ] Start with helpers for retrieving the closest parent `package.json` associated with a specifier string; and for retrieving the `package.json` for a particular package by name (which is not necessarily the same result).
 
    - [ ] Potentially include all the functions that make up the ESM resolution algorithm as defined in the [spec](https://nodejs.org/api/esm.html#resolver-algorithm-specification). Create helper functions for each of the functions defined in that psuedocode: `esmResolve`, `packageImportsResolve`, `packageResolve`, `esmFileFormat`, `packageSelfResolve`, `readPackageJson`, `packageExportsResolve`, `lookupPackageScope`, `packageTargetResolve`, `packageImportsExportsResolve`, `patternKeyCompare`. (Not necessarily all with these exact names, but corresponding to these functions from the spec.)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 
 - [x] Implement chaining as described in the [design](doc/design/proposal-chaining-middleware.md), where the `default<hookName>` becomes `next` and references the next registered hook in the chain. https://github.com/nodejs/node/pull/42623
 
-- [ ] Move loaders off thread.
+- [ ] Move loaders off thread. https://github.com/nodejs/node/issues/43658
 
    We hope that moving loaders off thread will allow us to preserve an async `resolve` hook while supporting the sync `import.meta.resolve` API. If that turns out to be unachievable, however, then:
 


### PR DESCRIPTION
I added @cspotcode’s suggestions from https://github.com/nodejs/node/issues/43818#issuecomment-1184415188 to our roadmap, and split the roadmap into two phases: the first which is for ESM to achieve parity with CommonJS, and the second is for everything else 😄 

1. Is there anything I’m missing from this list?
2. Is there anything that’s under the wrong heading (something in the second phase that _is_ required for parity with CommonJS, or something in the first phase that _isn’t_ required for parity with CommonJS)?

Also, I added finishing `--experimental-vm-modules` to this list because it comes up as one of the missing pieces in ESM; it’s the biggest thing holding Jest back, for instance. But I wonder how essential it is? I understand that the Jest team surely would prefer not to refactor away from using `vm` under the hood, but Vitest seems to support most (almost all?) of Jest’s API and claims full ESM support. Are improvements to `vm` truly needed for ESM to achieve parity with CommonJS? “Parity” here being defined as the capabilities end users have access to once package authors refactor, to swap out one API for another (just as they had to use loader hooks instead of `require.extensions`).