### PR TITLE
Update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 
       - [ ] Consider an API for async operations before resolution begins, such as `preImport` https://github.com/nodejs/loaders/pull/89
 
-- [ ] Provide a way to register loaders without a command-line flag, for example via a `"loaders"` field in `package.json` ([#98](https://github.com/nodejs/loaders/issues/98)).
+### Milestone 2: Usability improvements
+
+- [ ] Provide a way to register loaders without a command-line flag, for example via a `"loaders"` field in `package.json` ([#98](https://github.com/nodejs/loaders/issues/98) or https://github.com/nodejs/node/pull/43973).
 
 - [ ] Support loading source when the return value of `load` has `format: 'commonjs'`. See https://github.com/nodejs/node/issues/34753#issuecomment-735921348 and https://github.com/nodejs/loaders-test/blob/835506a638c6002c1b2d42ab7137db3e7eda53fa/coffeescript-loader/loader.js#L45-L50.
-
-### Milestone 2: Usability improvements
 
 - [ ] First-class support for [import maps](https://github.com/WICG/import-maps) that doesn’t require a custom loader.
 


### PR DESCRIPTION
I’m thinking that maybe the only thing on our roadmap that needs to happen before we move loaders out of experimental status is the task about moving loaders off-thread (and potentially renaming flags that might come with that). These were the other two we had:

- Telling Node to use particular loaders via configuration file. This seems like it might become a much bigger challenge, since it should support (eventually) most/all of Node’s configuration. But I think this can be a follow-on improvement, as it’s more of a UX convenience than a required feature.
- Supporting `format: 'commonjs'`. I’m not sure if this is even still an issue, but if it is, it’s arguably a bug in the implementation more than anything else. We can fix it at any time without causing a breaking change, and the current scope of loaders is that they’re not expected to handle CommonJS (yet) and that traditional CommonJS loaders are still needed for now (via `require.extensions` or monkey-patching). So I don’t think this should really block moving loaders to stable, either, as it can be fixed (and loaders more broadly extended to support CommonJS) as later improvements.

What do you think? There’s a big benefit to getting loaders out of experimental status in that that’s what many people are waiting for to start supporting the API “officially,” such as instrumentation vendors. The sooner we can declare loaders stable, the sooner all of ESM is considered stable and ready for production use. And I think aside from the off-thread thing, we’re already there.

This doesn’t mean that work won’t continue on loaders after this last Phase 1 item; but such follow-up work would need to follow semver regarding breaking changes. But I don’t think anything remaining on our list besides the off-thread/flags change would potentially involve any breaking changes? @nodejs/loaders 