### PR TITLE
Update roadmap: add `register` API idea, link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 
 ### Milestone 2: Usability improvements
 
-- [ ] Provide a way to register loaders without a command-line flag, for example via a `"loaders"` field in `package.json` ([#98](https://github.com/nodejs/loaders/issues/98) or https://github.com/nodejs/node/pull/43973).
+- [ ] Provide a way to register loaders without a command-line flag, for example via a `"nodeOptions"` field in `package.json` ([#98](https://github.com/nodejs/loaders/issues/98) or https://github.com/nodejs/node/pull/43973 or https://github.com/nodejs/node/pull/46534#issuecomment-1420041456).
+
+- [ ] Provide a way to register loaders programmatically, for example `import { registerLoader } from 'module'`.
 
 - [ ] Support loading source when the return value of `load` has `format: 'commonjs'`. See https://github.com/nodejs/node/issues/34753#issuecomment-735921348 and https://github.com/nodejs/loaders-test/blob/835506a638c6002c1b2d42ab7137db3e7eda53fa/coffeescript-loader/loader.js#L45-L50.
 


### PR DESCRIPTION
Add link, add idea we’ve been discussing around a programmatic way to register loaders.