### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,17 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 
 - [x] Move loaders off thread. https://github.com/nodejs/node/issues/43658, https://github.com/nodejs/node/pull/44710
 
-### Milestone 2: Usability improvements
+### Milestone 2: Stability
 
-- [ ] Provide a way to register loaders without a command-line flag, for example via a `"loaders"` field in `package.json`. See https://github.com/nodejs/node/pull/46826, [#98](https://github.com/nodejs/loaders/issues/98), https://github.com/nodejs/node/pull/43973.
+- [ ] Provide a way to register loaders from application code, such as `import { registerLoader } from 'module'`. https://github.com/nodejs/node/pull/46826.
+
+- [ ] Remove `globalPreload` hook; design a new API to preserve the communications channel from that hook so that we continue to provide a way to communicate between loaders code and application code. See https://github.com/nodejs/loaders/discussions/124#discussioncomment-5735397.
 
 - [ ] Support loading source when the return value of `load` has `format: 'commonjs'`. See https://github.com/nodejs/node/issues/34753#issuecomment-735921348 and https://github.com/nodejs/loaders-test/blob/835506a638c6002c1b2d42ab7137db3e7eda53fa/coffeescript-loader/loader.js#L45-L50.
+
+### Milestone 3: Usability improvements
+
+- [ ] Provide a way to register loaders via configuration, for example via adding support for `.env` files to Node.js or having `node` read configuration from a new field in `package.json` or other configuration file. See https://github.com/nodejs/node/pull/46826, [#98](https://github.com/nodejs/loaders/issues/98), https://github.com/nodejs/node/pull/43973#issuecomment-1249549346.
 
 - [ ] First-class support for [import maps](https://github.com/WICG/import-maps) that doesn’t require a custom loader.
 
@@ -65,5 +71,3 @@ Before extending into new frontiers, we need to improve the loaders API enough t
 - [ ] Hooks for customizing filesystem calls, for allowing things like virtual filesystems or archives treated as volumes.
 
 - [ ] Inherit configuration blob to worker threads and child processes.
-
-- [ ] Provide a way for application code to communicate with loaders code.


### PR DESCRIPTION
Adding a new section to split apart what I think needs to happen before we consider the core Loaders API stable, and everything else that can come afterward.