### PR TITLE
2023-05-23 meeting notes

### DIFF
--- a/doc/meetings/2023-05-23.md
+++ b/doc/meetings/2023-05-23.md
@@ -20,7 +20,7 @@
 
 - Whether to deprecate/remove `--loader` flag. Something we might consider after landing `registerLoader`, to simplify overall API. (Loaders can just tell their users to swap `--loader` for `--import`).
 
-- Name align on `register`, so `import { register } from 'node:module'` for what’s currently called `registerLoader`, to provide a standard namespace for registering customization hooks for various APIs. For example, in the future:
+- Align name on `register`, so `import { register } from 'node:module'` for what’s currently called `registerLoader`, to provide a standard namespace for registering customization hooks for various APIs. For example, in the future:
 
   ```js
   import { register as moduleRegister } from 'node:module';

--- a/doc/meetings/2023-05-23.md
+++ b/doc/meetings/2023-05-23.md
@@ -1,0 +1,39 @@
+# Node.js  Loaders Team Meeting 2023-05-23
+
+## Links
+
+* **Recording**: https://www.youtube.com/watch?v=JAwwmD77vC4
+* **GitHub Issue**: https://github.com/nodejs/loaders/issues/141
+
+## Present
+
+* Loaders team: @nodejs/loaders
+* Antoine du Hamel @aduh95
+* Geoffrey Booth @GeoffreyBooth
+* Isaac Schlueter @isaacs
+* Jacob Smith @JakobJingleheimer
+
+
+## Notes
+
+### https://github.com/nodejs/node/pull/46826 `registerLoader()`
+
+- Whether to deprecate/remove `--loader` flag. Something we might consider after landing `registerLoader`, to simplify overall API. (Loaders can just tell their users to swap `--loader` for `--import`).
+
+- Name align on `register`, so `import { register } from 'node:module'` for what’s currently called `registerLoader`, to provide a standard namespace for registering customization hooks for various APIs. For example, in the future:
+
+  ```js
+  import { register as moduleRegister } from 'node:module';
+  import { register as fsRegister } from 'node:fs';
+  ```
+
+- Ensure there is a test-case for missing `--loader` flag (assert error thrown) until the follow-up where we remove that limitation. We should hold the first PR from being released until the follow-up also lands.
+
+- Jacob to handle follow-up (reunite ESMLoader classes) ~next week
+
+### https://github.com/nodejs/node/pull/47999 `handle CJS via ESMLoader`
+
+- Isaac to help with test-cases
+
+- Jacob to help after `registerLoader` follow-up
+


### PR DESCRIPTION
cc @nodejs/loaders

@isaacs @jlenon7 would you like me to add you to @nodejs/loaders so that you get team pings? That way I won’t have to try to remember to cc you explicitly.

@arcanis Note in here the discussion of renaming `registerLoader` to just `register`, as in `import { register } from 'node:module'`, to create precedent for a future `import { register } from 'node:fs'` and similar for other namespaces.